### PR TITLE
The official extension is .coal

### DIFF
--- a/coalton-mode.el
+++ b/coalton-mode.el
@@ -251,7 +251,7 @@
       (treesit-inspect-mode))
     (treesit-major-mode-setup)))
 
-(add-to-list 'auto-mode-alist '("\\.coalton\\'" . coalton-mode))
+(add-to-list 'auto-mode-alist '("\\.coal\\'" . coalton-mode))
 
 (defvar coalton--query-package
   (treesit-query-compile


### PR DESCRIPTION
This should be the only entry in auto-mode-alist for Coalton files.