### PR TITLE
Use updated compiler entry points

### DIFF
--- a/coalton-mode.el
+++ b/coalton-mode.el
@@ -26,8 +26,10 @@
 
 (defvar coalton-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-c") 'slime-coalton--compile-form)
-    (define-key map (kbd "C-c C-l") 'slime-coalton--compile-file)
+    (define-key map (kbd "C-c C-a") 'coalton-ast)
+    (define-key map (kbd "C-c C-g") 'coalton-codegen)
+    (define-key map (kbd "C-c C-l") 'coalton-compile)
+    (define-key map (kbd "C-c C-c") 'coalton-compile-form)
     map))
 
 (defvar coalton-mode-syntax-table
@@ -185,9 +187,9 @@ Displays current tree-sitter node in mode line, useful for nav and highlighting 
   (let ((C '(coalton-available-p)))
     `("Coalton"
       ("Debug"
-       [ "Show AST"         slime-coalton--ast-file ,C ])
+       [ "Show AST"         coalton-ast     ,C ])
       ("Compile"
-       [ "Compile File"     slime-coalton--compile-file ,C ]))))
+       [ "Compile File"     coalton-compile ,C ]))))
 
 (easy-menu-define menubar-coalton coalton-mode-map "Coalton" coalton-easy-menu)
 

--- a/slime-coalton.el
+++ b/slime-coalton.el
@@ -1,14 +1,17 @@
-;;; slime-coalton.el --- coalton-mode lisp integration -*- lexical-binding: t; -*-
-;;
-;; Slime extension via `define-slime-contrib' for interaction with a
-;; Coalton instance running in a Slime-managed Lisp subprocess.
+;;;; slime-coalton.el --- coalton-mode lisp integration -*- lexical-binding: t; -*-
+;;;;
+;;;; Slime extension via `define-slime-contrib' for interaction with a
+;;;; Coalton instance running in a Slime-managed Lisp subprocess.
 
 (require 'slime)
 
-(defun coalton-available-p ()
-  ;; todo: associate tests with specific connections
-  (and (not (null slime-net-processes))
-       (eql :loaded (slime-eval `(swank:swank-coalton-status)))))
+;; Ensure that slime is connected, coalton is loaded and swank components are loaded
+
+(defun check-connection ()
+  (unless (slime-connected-p)
+    (error "Connect to slime."))
+  ;; (eql :loaded (slime-eval `(swank:swank-coalton-status)))
+  )
 
 (cl-defmacro slime-coalton--show ((name) &body body)
   (declare (indent 1))
@@ -29,12 +32,14 @@
 
 (defun slime-coalton--popup (type value)
   (pop-to-buffer (slime-coalton--popup-buffer type))
+  (read-only-mode -1)
   (erase-buffer)
   (insert value)
   (goto-char (point-min)))
 
 (defun slime-coalton--eval (sexp cont)
   (declare (indent 1))
+  (check-connection)
   (slime-rex (cont)
       (sexp "swank")
     ((:ok result)
@@ -43,21 +48,38 @@
     ((:abort condition)
      (message "Evaluation aborted on %s." condition))))
 
-(defun slime-coalton--ast-file ()
-  "Display the AST of the current file."
+(defun coalton-ast ()
+  "Display the AST of the current buffer."
   (interactive)
-  (slime-coalton--eval `(swank:swank-coalton--ast-file
+  (slime-coalton--eval `(swank:swank-coalton--codegen
                          ,(buffer-substring-no-properties (point-min) (point-max)))
     (lambda (result)
       (slime-coalton--popup 'ast result))))
 
-(defun slime-coalton--compile-file ()
-  "Compile the current file."
+(defun coalton-codegen ()
+  "Display the compiled Lisp of the current buffer."
   (interactive)
-  (slime-coalton--eval `(swank:swank-coalton--compile-file
+  (slime-coalton--eval `(swank:swank-coalton--codegen
                          ,(buffer-substring-no-properties (point-min) (point-max)))
     (lambda (result)
-      (slime-coalton--popup 'ast result))))
+      (slime-coalton--popup 'codegen result))))
+
+(defun coalton-compile ()
+  "Compile the current buffer."
+  (interactive)
+  (slime-coalton--eval `(swank:swank-coalton--compile
+                         ,(buffer-substring-no-properties (point-min) (point-max)))
+    (lambda (result)
+      (slime-coalton--popup 'compile result))))
+
+(defun coalton-compile-form ()
+  "Redefine the toplevel form containing the current point."
+  (interactive)
+  (slime-coalton--eval `(swank:swank-coalton--compile-form
+                         ,(buffer-substring-no-properties (point-min) (point-max))
+                         (point))
+    (lambda (result)
+      (slime-coalton--popup 'compile result))))
 
 
 ;;; Initialization
@@ -68,10 +90,6 @@
 (define-slime-contrib slime-coalton
   "Support Coalton language"
   (:authors "Jesse Bouwman <jlbouwman@hrl.com>")
-  (:swank-dependencies swank-coalton))
-
-(defun coalton ()
-  (interactive)
-  (message "slime-coalton.el: coalton"))
+  (:swank-dependencies swank::swank-coalton))
 
 (provide 'slime-coalton)

--- a/swank-coalton.lisp
+++ b/swank-coalton.lisp
@@ -25,10 +25,11 @@
   (asdf:load-system "coalton"))
 
 
-(defslimefun swank-coalton--ast-file (text)
-  (with-input-from-string (stream text)
-    (coalton-impl/compiler::generate-ast stream)))
+(defslimefun swank-coalton--codegen (text)
+  (let ((source (coalton-impl/source:make-source-string text)))
+    (coalton-impl/entry:codegen source)))
 
-(defslimefun swank-coalton--compile-file (text)
-  (with-input-from-string (stream text)
-    (coalton-impl/compiler::%compile-file stream)))
+(defslimefun swank-coalton--compile (text)
+  (let ((source (coalton-impl/source:make-source-string text)))
+    (coalton-impl/entry:compile source :load t)
+    "Success"))


### PR DESCRIPTION
Use `coalton-impl/source` and `coalton-impl/entry` packages for interaction with compiler.