### PR TITLE
omnibus cleanup of first version of lsp

### DIFF
--- a/resources/fib.coal
+++ b/resources/fib.coal
@@ -2,7 +2,7 @@
   (import
     coalton-prelude)
   (export
-    fob))
+    fib))
 
 (declare fib (Integer -> Integer))
 (define (fib n)

--- a/src/lib/json.lisp
+++ b/src/lib/json.lisp
@@ -33,7 +33,9 @@
       (com.inuoe.jzon:write-value writer (com.inuoe.jzon:parse string)))))
 
 (defgeneric jzon-value (message-class value)
-  (:documentation "Convert a message to a value that can be directly serialized by jzon."))
+  (:documentation "Convert a message to a value that can be directly serialized by jzon.")
+  (:method (message-class value)
+    value))
 
 ;;; The values of atoms are all lisp atomic types that jzon serializes
 ;;; correctly.
@@ -43,9 +45,6 @@
          (or value 'null))
         (t
          (error "non-atom value in atom field: check the field type? value: ~s" value))))
-
-(defmethod jzon-value ((self message-enum) value)
-  value)
 
 ;;; Construct a jzon value, considering the 'vector and 'optional
 ;;; properties of a field.

--- a/src/lib/process.lisp
+++ b/src/lib/process.lisp
@@ -10,10 +10,10 @@
   (:method (process) "Coalton LSP Process"))
 
 (defgeneric run (process)
-  (:documentation "Run a process. This function is run by a newly started process. IF the function returns, the process will halt."))
+  (:documentation "The function run by a started process. The process halts when it returns."))
 
 (defgeneric stop (process)
-  (:documentation "Synchronously stop a process and immediately return."))
+  (:documentation "Synchronously stop a process."))
 
 (defclass process ()
   ((thread :initform nil)
@@ -32,8 +32,11 @@
 
 (defmethod stop ((self process))
   (with-slots (thread) self
-    (when thread
-      (bt:destroy-thread thread)
+    (when (and thread (bt:thread-alive-p thread))
+      (handler-case
+          (bt:destroy-thread thread)
+        (error (e)
+          (/warn "error during thread cleanup: ~a" e)))
       (setf thread nil)))
   self)
 
@@ -41,6 +44,8 @@
 
 (defvar *worker-poll-interval* 0.250
   "How long to sleep when there is no work to do.")
+
+(defvar *worker-debug* nil)
 
 (defclass worker (process)
   ((fn)
@@ -72,7 +77,8 @@
               (handler-case
                   (funcall (slot-value worker 'fn) element)
                 (condition (condition)
-                  (break)
+                  (when *worker-debug*
+                    (signal condition))
                   (/error "ignoring error : ~a" condition))))))
 
 (defmethod run ((self worker))
@@ -83,4 +89,4 @@
          (loop :while (run-p self)
                :do (service-queue self)
                    (sleep *worker-poll-interval*))
-      (/debug "exiting"))))
+      (/debug "stopping"))))

--- a/src/protocol.lisp
+++ b/src/protocol.lisp
@@ -46,11 +46,11 @@
   (:uri uri)
   (:range range))
 
-(define-union progress-token
+(define-union token
     (integer string))
 
 (define-message work-done-progress-params ()
-  (:work-done-token progress-token))
+  (:work-done-token token))
 
 ;;; Errors
 
@@ -516,7 +516,7 @@
 (define-message diagnostic ()
   (:range range)
   (:severity (diagnostic-severity :optional t))
-  (:code (string :optional t))          ; FIXME union int | str
+  (:code (token :optional t))
   (:source (string :optional t))
   (:message string)
   (:tags (diagnostic-tag :vector t :optional t))

--- a/tests/session-tests.lisp
+++ b/tests/session-tests.lisp
@@ -24,7 +24,7 @@
 
 (deftest session-tests/set-field ()
   (let ((params (lsp::make-message 'lsp::initialize-params)))
-    (lsp::message-value (lsp::set-field-1 params :capabilities 'x)))
+    (lsp::message-value (lsp::%set-key params :capabilities 'x)))
   (let ((params (lsp::make-message 'lsp::initialize-params)))
     (lsp::set-field params '(:capabilities :workspace) 'x)))
 


### PR DESCRIPTION
- provide default implementation of jzon-value
- improve naming of message key and path accessors
- conditionalize worker error debugging !- add document-changed notification