### PR TITLE
Fix the wrong Content-Length for UTF-8 response bodies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ following Lisp libraries:
 - bordeaux-threads
 - com.inuoe.jzon
 - usocket
+- trivial-utf-8
 
 ## Current Status
 

--- a/coalton-lsp.asd
+++ b/coalton-lsp.asd
@@ -5,7 +5,8 @@
                #:bordeaux-threads
                #:coalton
                #:com.inuoe.jzon
-               #:usocket)
+               #:usocket
+               #:trivial-utf-8)
   :pathname "src/"
   :serial t
   :components ((:file "package")

--- a/src/lib/rpc.lisp
+++ b/src/lib/rpc.lisp
@@ -138,7 +138,7 @@
 (defun %write-rpc (message stream)
   (let ((content (message-content message)))
     (write-headers stream
-                   `(("Content-Length" . ,(length content))
+                   `(("Content-Length" . ,(trivial-utf-8:utf-8-byte-length content))
                      ("Content-Type" . "application/json-rpc")))
     (write-sequence content stream)
     (force-output stream)))


### PR DESCRIPTION
The LSP server responds with a wrong Content-Length if the body contains UTF-8 characters such as `→`.